### PR TITLE
Support math directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "scopeName": "text.myst.injection",
         "embeddedLanguages": {
           "meta.embedded.block.markdown": "text.html.markdown",
-          "meta.embedded.block.ipython": "source.python"
+          "meta.embedded.block.ipython": "source.python",
+          "meta.embedded.block.latex": "latex"
         }
       }
     ]

--- a/src/myst.tmLanguage.yaml.j2
+++ b/src/myst.tmLanguage.yaml.j2
@@ -9,6 +9,7 @@ patterns:
   - { include: "#role_span" }
   - { include: "#div-directive-block-start" }
   - { include: "#directive-admonitions" }
+  - { include: "#directive-math" }
   - { include: "#directive-code" }
   - { include: "#directive-default" }
 
@@ -66,6 +67,32 @@ repository:
         patterns:
           - { include: text.html.markdown }
     name: markup.directive.admonition.myst
+
+  directive-math:
+    begin: (^|\G)(\s*)(`{3,}|~{3,})\{(math)\}\s*(?=([^`~]*)?$)
+    name: markup.directive.math.myst
+    end: (^|\G)(\2|\s{0,3})(\3)\s*$
+    beginCaptures:
+      '3': {name: 'punctuation.definition.myst'}
+      '4': {name: 'support.class.directive.myst'}
+      '5': {name: 'support.variable.language.myst'}
+    endCaptures:
+      '3': {name: 'punctuation.definition.myst'}
+    patterns:
+      - begin: (^|\G)(\s*)(.*)
+        while: (^|\G)(?!\s*([\`~]{3,})\s*$)
+        contentName: meta.embedded.block.latex
+        patterns:
+          - begin: (^|\G)(-{3})\s*$
+            beginCaptures:
+              '1': {name: 'punctuation.options.myst'}
+            end: (^|\G)(-{3})\s*$
+            endCaptures:
+              '2': {name: 'punctuation.options.myst'}
+            contentName: meta.embedded.block.options
+            patterns:
+              - {include: source.yaml}
+          - {include: text.html.markdown.math#math}
 
   directive-code:
     comment: These are directive blocks containing code

--- a/syntaxes/myst.tmLanguage
+++ b/syntaxes/myst.tmLanguage
@@ -36,6 +36,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#directive-math</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#directive-code</string>
 		</dict>
 		<dict>
@@ -196,6 +200,90 @@
 			</array>
 			<key>name</key>
 			<string>markup.directive.admonition.myst</string>
+		</dict>
+		<key>directive-math</key>
+		<dict>
+			<key>begin</key>
+			<string>(^|\G)(\s*)(`{3,}|~{3,})\{(math)\}\s*(?=([^`~]*)?$)</string>
+			<key>name</key>
+			<string>markup.directive.math.myst</string>
+			<key>end</key>
+			<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.myst</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>support.class.directive.myst</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>support.variable.language.myst</string>
+				</dict>
+			</dict>
+			<key>endCaptures</key>
+			<dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.myst</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)(\s*)(.*)</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*([\`~]{3,})\s*$)</string>
+					<key>contentName</key>
+					<string>meta.embedded.block.latex</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(^|\G)(-{3})\s*$</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.options.myst</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(^|\G)(-{3})\s*$</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.options.myst</string>
+								</dict>
+							</dict>
+							<key>contentName</key>
+							<string>meta.embedded.block.options</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.yaml</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>text.html.markdown.math#math</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 		</dict>
 		<key>directive-code</key>
 		<dict>


### PR DESCRIPTION
This add supports for highlighting the contents of the `math` directive as LaTeX. This was mostly made by fumbling around so it's quite possible I missed something, but at least it seems to work!